### PR TITLE
Fix header on top of screen

### DIFF
--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -18,6 +18,9 @@ body {
   background: #187795;
   color: white;
   font-size: 30px;
+  position: sticky;
+  top: 0px;
+  z-index: 1;
 }
 
 .dropzone {


### PR DESCRIPTION
# 📄 Context
When implementing the [PDF scrolling](https://github.com/MihaelsGit/CleverReader/pull/14), I've forgot to make the header sticky (fixed to the top of the screen). This PR fixes that.

# 📷 Screenshots
Before
![Screenshot 2022-11-27 at 12 10 21](https://user-images.githubusercontent.com/66385870/204132242-1026475e-aa34-4dba-8f64-5c18e87dae82.png)

After
![Screenshot 2022-11-27 at 12 10 44](https://user-images.githubusercontent.com/66385870/204132243-4eaf6cbd-ec5b-406f-8ff3-8736de90e477.png)
