### PR TITLE
Feat/clippy 63

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,8 +12,6 @@ import { projectName } from "./constants/strings";
 import KnowledgeGraph from "./components/KnowledgeGraph";
 
 function App() {
-  const [fileID, setFileID] = useState("");
-
   const [summaryModalShow, setSummaryModalShow] = useState(false);
   const [summaryText, setSummaryText] = useState("");
 
@@ -45,15 +43,14 @@ function App() {
             path="/"
             element={
               <FileUpload
-                setFileId={setFileID}
                 setKnowledgeGraph={setKnowledgeGraph}
                 setLoading={setLoading}
               />
             }
           />
           <Route
-            path="/viewFile"
-            element={<PDFViewer fileID={fileID} setLoading={setLoading} />}
+            path="/viewFile/"
+            element={<PDFViewer setLoading={setLoading} />}
           />
           <Route exact path="/knowledgeGraph" element={<KnowledgeGraph />} />
         </Routes>

--- a/src/components/FileUpload.js
+++ b/src/components/FileUpload.js
@@ -36,6 +36,7 @@ export default function FileUpload({ setLoading }) {
           setLoading(false);  
         } else {
           localStorage.setItem("FILE_ID", res);
+          navigate("/viewFile", {replace: true});
         }
       }
     };

--- a/src/components/FileUpload.js
+++ b/src/components/FileUpload.js
@@ -10,13 +10,9 @@ import "../styles/error.css";
 import { useNavigate } from "react-router-dom";
 import toast, { Toaster } from "react-hot-toast";
 
-export default function FileUpload({ setFileId, setLoading }) {
+export default function FileUpload({ setLoading }) {
   const [pdfFile, setPdf] = useState(null);
   const navigate = useNavigate();
-  useEffect(() => {
-    setFileId("");
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   useEffect(() => {
     if (pdfFile !== null && pdfFile.type !== "application/pdf") {
@@ -39,14 +35,13 @@ export default function FileUpload({ setFileId, setLoading }) {
             id: "toast"});
           setLoading(false);  
         } else {
-          navigate("/viewFile");
-          setFileId(res);
+          localStorage.setItem("FILE_ID", res);
         }
       }
     };
 
     submit();
-  }, [pdfFile, navigate, setFileId, setLoading]);
+  }, [pdfFile, navigate, setLoading]);
 
   return (
     <div className="dropzone">

--- a/src/components/NavigationBar.js
+++ b/src/components/NavigationBar.js
@@ -18,7 +18,7 @@ function NavigationBar({
       {pathname !== "/" ? (
         <div>
             <div className="navLeft">
-              <Link to="/" className="link">
+              <Link to="/" className="link" replace>
                 <TooltipIconButton
                   id="backButton"
                   tooltipText={"Back"}

--- a/src/components/PDFViewer.js
+++ b/src/components/PDFViewer.js
@@ -12,12 +12,13 @@ import { FaPlus, FaMinus } from "react-icons/fa";
 import { initializeViewer } from "../utils/initializePDF";
 import { zoomIn, zoomOut } from "../utils/viewerFunctions";
 
-export default function PDFViewer({ fileID, setLoading }) {
+export default function PDFViewer({ setLoading }) {
   const [pdfURL, setPdfURL] = useState("");
   const [viewer, setViewer] = useState(null);
 
   useEffect(() => {
     setLoading(true);
+    let fileID = localStorage.getItem("FILE_ID");
     if (fileID !== "") {
       let path = BASE_URL + fileID;
       setPdfURL(path);
@@ -28,7 +29,7 @@ export default function PDFViewer({ fileID, setLoading }) {
         console.log("Error showing PDF :( => ", err);
       }
     }
-  }, [fileID, pdfURL, setLoading]);
+  }, [pdfURL, setLoading]);
 
   return (
     <div className="container">


### PR DESCRIPTION
## 📄 Context

This PR includes task [`CLIPPY-63: Fix PDF preview state invalidation`](https://clippy4.atlassian.net/browse/CLIPPY-63).

I've stored fileID to localStorage for using it on PDF Viewer page instead of using hooks. Now the page re-renders itself correctly on refresh.
I've also changed navigation by ditching adding pages to navigation stack and instead replacing every page with during navigation. The users can still navigate to the upload page, but only using the back button (I think this is okay, because enabling page stacking we could have a lot of possible state related issues).

