### PR TITLE
Feat/clippy 45

### DIFF
--- a/src/utils/renderPopup.js
+++ b/src/utils/renderPopup.js
@@ -16,7 +16,7 @@ export const onReferenceHover = async (e, pdfDoc, pdfLinkServ) => {
     previewStyle.position = "fixed";
     previewStyle.zIndex = "99";
     previewStyle.top = `${e.clientY + 4}px`;
-    previewStyle.boxShadow = "5px 5px 5px black, -5px 5px 5px black";
+    previewStyle.boxShadow = "5px 5px 5px gray, -5px 5px 5px gray";
 
     const namedDest = decodeURIComponent(hash.substring(1));
     const explicitDest =

--- a/src/utils/renderPopup.js
+++ b/src/utils/renderPopup.js
@@ -27,9 +27,9 @@ export const onReferenceHover = async (e, pdfDoc, pdfLinkServ) => {
 
     pdfDoc.getPage(pageNumber).then((page) => {
       const curr_scale = pdfLinkServ.pdfViewer._currentScale;
-      const tempViewport = page.getViewport(curr_scale);
-      const height = tempViewport.height * 1.2 * curr_scale;
-      const width = tempViewport.width * 1.2 * curr_scale;
+      const tempViewport = page.getViewport(1);
+      const height = Math.floor(tempViewport.height * curr_scale* 1);
+      const width = Math.floor(tempViewport.width * curr_scale * 1);
       const leftOffset = e.clientX > halfWidth ? (2 * width) / 3 : width / 3;
       previewStyle.height = `${height}px`;
       previewStyle.width = `${width}px`;
@@ -47,20 +47,23 @@ export const onReferenceHover = async (e, pdfDoc, pdfLinkServ) => {
           offsetY = explicitDest[2];
           break;
         default:
+          offsetY = 0;
           console.log(`Oops, link ${explicitDest[1].name} is not supported.`);
       }
 
-      const scale = curr_scale / 4;
+      const previewScale = curr_scale * 0.75;
       const viewport = page.getViewport({
-        scale,
-        offsetY: (offsetY - tempViewport.height) * scale,
+        scale: previewScale,
       });
 
-      preview.height = viewport.height;
+      preview.heigh = viewport.height;
       preview.width = viewport.width;
+
+      var transform =  previewScale !== 1 ? [previewScale, 0, 0, previewScale, 0, 0] : null;
 
       const renderContext = {
         canvasContext: preview.getContext("2d"),
+        transform: transform,
         viewport: viewport,
       };
       page.render(renderContext);

--- a/src/utils/renderPopup.js
+++ b/src/utils/renderPopup.js
@@ -1,0 +1,75 @@
+export const onReferenceHover = async (e, pdfDoc, pdfLinkServ) => {
+  const el = e.target;
+  const parent = el.parentElement;
+  const hash = el.hash;
+
+  const destinations = await pdfDoc.getDestinations();
+
+  if (el.className === "internalLink") {
+    const box = el.getBoundingClientRect();
+    const halfWidth = (box.left + box.right) / 2;
+
+    const preview = document.createElement("canvas");
+    const previewStyle = preview.style;
+    previewStyle.border = "1px solid black";
+    previewStyle.direction = "ltr";
+    previewStyle.position = "fixed";
+    previewStyle.zIndex = "99";
+    previewStyle.top = `${e.clientY + 4}px`;
+    previewStyle.boxShadow = "5px 5px 5px black, -5px 5px 5px black";
+
+    const namedDest = decodeURIComponent(hash.substring(1));
+    const explicitDest =
+      namedDest in destinations
+        ? destinations[namedDest]
+        : JSON.parse(namedDest);
+    const pageNumber = pdfLinkServ._cachedPageNumber(explicitDest[0]);
+
+    pdfDoc.getPage(pageNumber).then((page) => {
+      const curr_scale = pdfLinkServ.pdfViewer._currentScale;
+      const tempViewport = page.getViewport(curr_scale);
+      const height = tempViewport.height * 1.2 * curr_scale;
+      const width = tempViewport.width * 1.2 * curr_scale;
+      const leftOffset = e.clientX > halfWidth ? (2 * width) / 3 : width / 3;
+      previewStyle.height = `${height}px`;
+      previewStyle.width = `${width}px`;
+      previewStyle.left = `${e.clientX - leftOffset - 4}px`;
+
+      let offsetY;
+      switch (explicitDest[1].name) {
+        case "XYZ":
+          offsetY = explicitDest[3];
+          break;
+        case "FitH":
+        case "FitBH":
+        case "FitV":
+        case "FitBV":
+          offsetY = explicitDest[2];
+          break;
+        default:
+          console.log(`Oops, link ${explicitDest[1].name} is not supported.`);
+      }
+
+      const scale = curr_scale / 4;
+      const viewport = page.getViewport({
+        scale,
+        offsetY: (offsetY - tempViewport.height) * scale,
+      });
+
+      preview.height = viewport.height;
+      preview.width = viewport.width;
+
+      const renderContext = {
+        canvasContext: preview.getContext("2d"),
+        viewport: viewport,
+      };
+      page.render(renderContext);
+    });
+
+    el.prepend(preview);
+
+    parent.addEventListener("mouseleave", (e) => {
+      preview.remove();
+    });
+  }
+};

--- a/src/utils/renderPopup.js
+++ b/src/utils/renderPopup.js
@@ -68,6 +68,7 @@ export const onReferenceHover = async (e, pdfDoc, pdfLinkServ) => {
 
     el.prepend(preview);
 
+    parent.after(preview);
     parent.addEventListener("mouseleave", (e) => {
       preview.remove();
     });

--- a/src/utils/renderPopup.js
+++ b/src/utils/renderPopup.js
@@ -65,6 +65,7 @@ export const onReferenceHover = async (e, pdfDoc, pdfLinkServ) => {
         canvasContext: preview.getContext("2d"),
         transform: transform,
         viewport: viewport,
+        offsetY: offsetY
       };
       page.render(renderContext);
     });

--- a/src/utils/renderPopup.js
+++ b/src/utils/renderPopup.js
@@ -56,7 +56,7 @@ export const onReferenceHover = async (e, pdfDoc, pdfLinkServ) => {
         scale: previewScale,
       });
 
-      preview.heigh = viewport.height;
+      preview.height = 300;
       preview.width = viewport.width;
 
       var transform =  previewScale !== 1 ? [previewScale, 0, 0, previewScale, 0, 0] : null;


### PR DESCRIPTION
## 📄 Context

This PR includes task [`CLIPPY-45: Reference hover`](https://clippy4.atlassian.net/browse/CLIPPY-45).

Now the users are able to hover but the hovering preview doesn't precisely show the reference

I've also hardcoded the height since the preview always starts from top page so I thought it would be best to show a bit more of the page, here are the screenshots:

<img width="100%" alt="Screenshot 2023-01-06 at 17 30 43" src="https://user-images.githubusercontent.com/66385870/211055194-abc7709e-9d06-4575-8988-154708a35391.png">
<img width="100%" alt="Screenshot 2023-01-06 at 17 30 35" src="https://user-images.githubusercontent.com/66385870/211055220-925601b1-0eba-4ea2-84b6-460f57d8da80.png">

